### PR TITLE
Multi dotted directory or filename fix

### DIFF
--- a/lib/txtify.js
+++ b/lib/txtify.js
@@ -10,7 +10,7 @@
     excludeExtensions: ['.ts', '.js']
   }, function(content, opts, done) {
     var ext, regex, result;
-    regex = /(\..+)$/gm;
+    regex = /(\.\w+)$/gm;
     ext = regex.exec(opts.file)[1];
     if (opts.config.extensions.indexOf(ext) >= 0) {
       result = null;

--- a/src/txtify.coffee
+++ b/src/txtify.coffee
@@ -3,7 +3,7 @@ transformTools = require 'browserify-transform-tools'
 
 module.exports = transformTools.makeStringTransform 'txtify', {excludeExtensions: ['.ts','.js']}, (content, opts, done) ->
   # chunkPath = opts.config.chunkPath || ''
-  regex = /(\..+)$/gm;
+  regex = /(\.\w+)$/gm;
   ext = regex.exec(opts.file)[1];
   if opts.config.extensions.indexOf(ext) >= 0
     result = null;


### PR DESCRIPTION
It isn't able to recognize extension if includes dotted path. 

example)
/var/www/your.domain.com/includes/somefile.txt
/home/you/work/somefile.template.txt
